### PR TITLE
Better error handling of conceptschemes that fail to load. Refs #101

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,4 +24,4 @@ keywords:
   - Vocabulary
 license: MIT
 version: 1.2.1
-date-released: '2023-10-19'
+date-released: '2023-10-??'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,8 @@
-1.2.1 (2023-10-19)
+1.2.1 (2023-10-??)
 ------------------
 
 - Update Pyramid dependency to 2.0.2
+- Better handling of rendering a list of conceptschemes when one is unreachable. (#101)
 
 1.2.0 (2023-03-08)
 ------------------

--- a/pyramid_skosprovider/views.py
+++ b/pyramid_skosprovider/views.py
@@ -142,7 +142,7 @@ class ProviderView(RestView):
                 if label := p.concept_scheme.label(language):
                     cslabel = label.label
                 else:
-                    cslabel = None
+                    cslabel = p.get_vocabulary_uri()
             except ProviderUnavailableException as e:
                 log.error(f'Could not fetch label for {p.get_vocabulary_uri()}: %s', e)
                 cslabel = p.get_vocabulary_uri()

--- a/pyramid_skosprovider/views.py
+++ b/pyramid_skosprovider/views.py
@@ -12,6 +12,8 @@ from pyramid.httpexceptions import (
     HTTPBadRequest
 )
 
+from skosprovider.exceptions import ProviderUnavailableException
+
 from pyramid_skosprovider.utils import (
     parse_range_header,
     QueryBuilder
@@ -134,16 +136,23 @@ class ProviderView(RestView):
             '@id': 'dct:subject',
             '@type': '@id'
         }
-        return [
-            {
+        conceptschemes = []
+        for p in self.skos_registry.get_providers():
+            try:
+                cslabel = p.concept_scheme.label(language).label if p.concept_scheme.label(language) else None,
+            except ProviderUnavailableException as e:
+                log.error('Could not fetch label for {p.get_vocabulary_uri()}', e) 
+                cslabel = p.get_vocabulary_uri()
+            cs = {
                 '@context': context,
                 'type': 'skos:ConceptScheme',
                 'id': p.get_vocabulary_id(),
-                'uri': p.concept_scheme.uri,
-                'label': p.concept_scheme.label(language).label if p.concept_scheme.label(language) else None,
+                'uri': p.get_vocabulary_uri(),
+                'label': cslabel,
                 'subject': p.metadata['subject'] if p.metadata['subject'] else []
-            } for p in self.skos_registry.get_providers()
-        ]
+            }
+            conceptschemes.append(cs)
+        return conceptschemes
 
     @view_config(
         route_name='skosprovider.conceptscheme',

--- a/pyramid_skosprovider/views.py
+++ b/pyramid_skosprovider/views.py
@@ -139,9 +139,12 @@ class ProviderView(RestView):
         conceptschemes = []
         for p in self.skos_registry.get_providers():
             try:
-                cslabel = p.concept_scheme.label(language).label if p.concept_scheme.label(language) else None,
+                if label := p.concept_scheme.label(language):
+                    cslabel = label.label
+                else:
+                    cslabel = None
             except ProviderUnavailableException as e:
-                log.error('Could not fetch label for {p.get_vocabulary_uri()}', e) 
+                log.error(f'Could not fetch label for {p.get_vocabulary_uri()}: %s', e)
                 cslabel = p.get_vocabulary_uri()
             cs = {
                 '@context': context,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -178,6 +178,21 @@ class ProviderViewTests(unittest.TestCase):
             for cs in conceptschemes:
                 assert cs["label"] == "https://vocabulary-uri"
 
+    def test_get_conceptschemes_provider_no_label(self):
+        request = self._get_dummy_request()
+        pv = self._get_provider_view(request)
+
+        with mock.patch(
+            "skosprovider.skos.ConceptScheme.label",
+            new=Mock(return_value=None),
+        ), mock.patch(
+            "skosprovider.providers.VocabularyProvider.get_vocabulary_uri",
+            new=Mock(return_value="https://vocabulary-uri"),
+        ):
+            conceptschemes = pv.get_conceptschemes()
+            for cs in conceptschemes:
+                assert cs["label"] == "https://vocabulary-uri"
+
     def test_get_conceptschemes_jsonld(self):
         request = self._get_dummy_request()
         request.accept = 'application/ld+json'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,10 @@
 # -*- coding: utf8 -*-
 
 import logging
+from unittest import mock
+from unittest.mock import Mock
+from unittest.mock import PropertyMock
+
 from pyramid import testing
 
 from pyramid.httpexceptions import (
@@ -9,6 +13,8 @@ from pyramid.httpexceptions import (
 
 import unittest
 import pytest
+from skosprovider.exceptions import ProviderUnavailableException
+
 from .fixtures.data import (
     trees
 )
@@ -49,6 +55,7 @@ class StaticViewTests(unittest.TestCase):
         assert isinstance(ctxt, dict)
         assert '@context' in ctxt
         assert 'skos' in ctxt['@context']
+
 
 class ProviderViewTests(unittest.TestCase):
 
@@ -156,6 +163,21 @@ class ProviderViewTests(unittest.TestCase):
             assert 'uri' in cs
             assert 'label' in cs
 
+    def test_get_conceptschemes_provider_unavailable(self):
+        request = self._get_dummy_request()
+        pv = self._get_provider_view(request)
+
+        with mock.patch(
+            "skosprovider.providers.VocabularyProvider.concept_scheme",
+            new=PropertyMock(side_effect=ProviderUnavailableException("test")),
+        ), mock.patch(
+            "skosprovider.providers.VocabularyProvider.get_vocabulary_uri",
+            new=Mock(return_value="https://vocabulary-uri"),
+        ):
+            conceptschemes = pv.get_conceptschemes()
+            for cs in conceptschemes:
+                assert cs["label"] == "https://vocabulary-uri"
+
     def test_get_conceptschemes_jsonld(self):
         request = self._get_dummy_request()
         request.accept = 'application/ld+json'
@@ -168,7 +190,6 @@ class ProviderViewTests(unittest.TestCase):
             assert 'uri' in cs
             assert 'label' in cs
             assert '@context' in cs
-
 
     def test_get_conceptscheme(self):
         request = self._get_dummy_request()


### PR DESCRIPTION
In case the CS fails to load, fall back on the CS uri as a label since that one's always present.

@Wim-De-Clercq Could you review and provide a unit tests that tests the error handling?